### PR TITLE
Add support for Jade templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "gulp-gh-pages": "^0.5.4",
     "html-loader": "^0.4.0",
     "html-webpack-plugin": "^1.7.0",
+    "jade-react-loader": "^1.0.2",
     "markdown-loader": "^0.1.7",
     "react-hot-loader": "^1.3.0",
     "style-loader": "^0.13.0",

--- a/src/components/Header/Header.jade
+++ b/src/components/Header/Header.jade
@@ -1,0 +1,6 @@
+header(class=styles.header)
+  h1
+    a(href='#/') React Stylus Webpack boilerplate
+  h2 A starter kit for creating applications using react and stylus
+  a(class=styles.stylusLogo href='https://learnboost.github.io/stylus/')
+  a(class=styles.reactLogo href='https://facebook.github.io/react/')

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,13 +1,6 @@
 import styles from './Header.styl';
-import React from 'react';
+import template from './Header.jade';
 
-const Header = () => (
-  <header className={styles.header}>
-    <h1><a href="#/">React Stylus Webpack boilerplate</a></h1>
-    <h2>A starter kit for creating applications using react and stylus</h2>
-    <a className={styles.stylusLogo} href="https://learnboost.github.io/stylus/"></a>
-    <a className={styles.reactLogo} href="https://facebook.github.io/react/"></a>
-  </header>
-);
+const Header = () => template({ styles });
 
 export default Header;

--- a/webpack.dev-server.config.js
+++ b/webpack.dev-server.config.js
@@ -34,6 +34,9 @@ export default {
       test: /\.png$/,
       loader: 'file-loader?name=images/[name].[ext]?[hash]'
     }, {
+      test: /\.jade$/,
+      loader: 'jade-react-loader'
+    }, {
       test: /\.md$/,
       loader: 'html!markdown'
     }]


### PR DESCRIPTION
This PR provides support for requiring jade templates with a small component shim to include styles, using `jade-react-loader`.
### Jade template

``` jade
header(class=styles.header)
  h1
    a(href='#/') React Stylus Webpack boilerplate
  h2 A starter kit for creating applications using react and stylus
  a(class=styles.stylusLogo href='https://learnboost.github.io/stylus/')
  a(class=styles.reactLogo href='https://facebook.github.io/react/')
```
### React component

``` javascript
import styles from './Header.styl';
import template from './Header.jade';

const Header = () => template({ styles });

export default Header;
```
