### PR TITLE
[FIX] Added missing jade loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 dist
 .publish
 *.iml
+.idea

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -27,6 +27,9 @@ export default {
       test: /\.png$/,
       loader: 'file-loader?name=images/[name].[ext]?[hash]'
     }, {
+      test: /\.jade$/,
+      loader: 'jade-react-loader'
+    }, {
       test: /\.md$/,
       loader: 'html!markdown'
     }]


### PR DESCRIPTION
Fixed missing loader jade error when running "gulp build" command into webpack production configuration.

```

ERROR in ./src/components/Header/Header.jade
Module parse failed: /Users/vav/Documents/nestor/react-stylus-webpack-boilerplate/src/components/Header/Header.jade Unexpected token (1:12)
You may need an appropriate loader to handle this file type.
```

And added .idea into .gitignore
